### PR TITLE
Update php dependencies

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,13 +31,13 @@ jobs:
         run: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress
 
       - name: Run PHP CS Fixer
-        run: vendor/bin/php-cs-fixer fix -v --dry-run --using-cache=no
+        run: composer phpcs
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyze -c phpstan.neon
+        run: composer phpstan
 
       - name: Execute tests
-        run: vendor/bin/phpunit --verbose --coverage-text --coverage-clover=coverage.clover
+        run: composer phpunit:coverage
 
       - name: Code coverage
         if: ${{ github.ref == 'refs/heads/master' && matrix.php != 8.0 }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 /vendor/
-/.php_cs.cache
+/.php-cs-fixer.cache
 /.phpunit.result.cache
 /coverage/
 /coverage.xml
+/coverage.clover
 /composer.lock
 /.idea/

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -1,10 +1,12 @@
 <?php
 
+use PhpCsFixer\Config;
+
 $finder = PhpCsFixer\Finder::create()
     ->exclude('CodeGeneration/Fixtures')
     ->in(__DIR__.'/src/');
 
-return PhpCsFixer\Config::create()
+return (new Config())
     ->setRules([
         '@Symfony' => true,
         'concat_space' => ['spacing' => 'one'],

--- a/composer.json
+++ b/composer.json
@@ -18,13 +18,21 @@
         "psr/clock-implementation": "1.0"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12.82",
-        "phpunit/phpunit": "^9.4",
-        "friendsofphp/php-cs-fixer": "^2.18.4"
+        "phpstan/phpstan": "^2.0",
+        "phpunit/phpunit": "^9.6",
+        "friendsofphp/php-cs-fixer": "^v3.65.0"
     },
     "autoload": {
         "psr-4": {
             "EventSauce\\Clock\\": "src/"
         }
+    },
+    "scripts": {
+        "phpunit": "phpunit",
+        "phpunit:coverage": "XDEBUG_MODE=coverage phpunit --verbose --coverage-text=coverage.clover",
+        "phpcs": "php-cs-fixer fix -v --dry-run --using-cache=no",
+        "phpcs:fix": "php-cs-fixer fix",
+        "phpstan": "phpstan analyze -c phpstan.neon",
+        "check" : ["@phpcs", "@phpstan", "@phpunit"]
     }
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,8 +2,8 @@ parameters:
     level: max
     paths:
         - src
-    excludes_analyse:
-        - %rootDir%/../../../src/CodeGeneration/Fixtures/*
-        - %rootDir%/../../../src/LibraryConsumptionTests/*
-        - *Test.php
-    checkMissingIterableValueType: false
+    excludePaths:
+        analyse:
+            - %rootDir%/../../../src/CodeGeneration/Fixtures/*
+            - %rootDir%/../../../src/LibraryConsumptionTests/*
+            - *Test.php

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -6,14 +6,14 @@
         </testsuite>
     </testsuites>
 
-    <filter>
-        <whitelist>
-            <directory>src/</directory>
-            <exclude>
-                <directory suffix="Test.php">src/</directory>
-                <directory suffix="Fixture.php">src/</directory>
-                <directory suffix=".php">src/CodeGeneration/Fixtures/</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+    <coverage>
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+        <exclude>
+            <directory suffix="Test.php">src/</directory>
+            <directory suffix="Fixture.php">src/</directory>
+            <directory suffix=".php">src/CodeGeneration/Fixtures/</directory>
+        </exclude>
+    </coverage>
 </phpunit>

--- a/src/Clock.php
+++ b/src/Clock.php
@@ -4,13 +4,11 @@ declare(strict_types=1);
 
 namespace EventSauce\Clock;
 
-use DateTimeImmutable;
-use DateTimeZone;
 use Psr\Clock\ClockInterface;
 
 interface Clock extends ClockInterface
 {
-    public function now(): DateTimeImmutable;
+    public function now(): \DateTimeImmutable;
 
-    public function timeZone(): DateTimeZone;
+    public function timeZone(): \DateTimeZone;
 }

--- a/src/SystemClock.php
+++ b/src/SystemClock.php
@@ -4,24 +4,21 @@ declare(strict_types=1);
 
 namespace EventSauce\Clock;
 
-use DateTimeImmutable;
-use DateTimeZone;
-
 class SystemClock implements Clock
 {
-    private DateTimeZone $timeZone;
+    private \DateTimeZone $timeZone;
 
-    public function __construct(DateTimeZone $timeZone = null)
+    public function __construct(?\DateTimeZone $timeZone = null)
     {
-        $this->timeZone = $timeZone ?: new DateTimeZone('UTC');
+        $this->timeZone = $timeZone ?: new \DateTimeZone('UTC');
     }
 
-    public function now(): DateTimeImmutable
+    public function now(): \DateTimeImmutable
     {
-        return new DateTimeImmutable('now', $this->timeZone);
+        return new \DateTimeImmutable('now', $this->timeZone);
     }
 
-    public function timeZone(): DateTimeZone
+    public function timeZone(): \DateTimeZone
     {
         return $this->timeZone;
     }

--- a/src/SystemClockTest.php
+++ b/src/SystemClockTest.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 
 namespace EventSauce\Clock;
 
-use DateTimeZone;
 use PHPUnit\Framework\TestCase;
-use function usleep;
 
 class SystemClockTest extends TestCase
 {
@@ -17,7 +15,7 @@ class SystemClockTest extends TestCase
     {
         $clock = new SystemClock();
         $d1 = $clock->now();
-        usleep(1);
+        \usleep(1);
         $d2 = $clock->now();
         $this->assertTrue($d1 < $d2);
     }
@@ -36,7 +34,7 @@ class SystemClockTest extends TestCase
      */
     public function setting_a_timezone_explicitly(): void
     {
-        $clock = new SystemClock(new DateTimeZone('Europe/Amsterdam'));
+        $clock = new SystemClock(new \DateTimeZone('Europe/Amsterdam'));
         $this->assertEquals('Europe/Amsterdam', $clock->timeZone()->getName());
     }
 }

--- a/src/TestClock.php
+++ b/src/TestClock.php
@@ -4,53 +4,48 @@ declare(strict_types=1);
 
 namespace EventSauce\Clock;
 
-use DateInterval;
-use DateTimeImmutable;
-use DateTimeZone;
-use InvalidArgumentException;
-
 class TestClock implements Clock
 {
     /**
      * @private
      */
-    const FORMAT_OF_TIME = 'Y-m-d H:i:s.uO';
-    private DateTimeImmutable $time;
-    private DateTimeZone $timeZone;
+    public const FORMAT_OF_TIME = 'Y-m-d H:i:s.uO';
+    private \DateTimeImmutable $time;
+    private \DateTimeZone $timeZone;
 
-    public function __construct(DateTimeZone $timeZone = null)
+    public function __construct(?\DateTimeZone $timeZone = null)
     {
-        $this->timeZone = $timeZone ?: new DateTimeZone('UTC');
+        $this->timeZone = $timeZone ?: new \DateTimeZone('UTC');
         $this->tick();
     }
 
     public function tick(): void
     {
-        $this->time = new DateTimeImmutable('now', $this->timeZone);
+        $this->time = new \DateTimeImmutable('now', $this->timeZone);
     }
 
     public function fixate(string $input, string $format = '!Y-m-d H:i:s'): void
     {
-        $dateTime = DateTimeImmutable::createFromFormat($format, $input, $this->timeZone);
+        $dateTime = \DateTimeImmutable::createFromFormat($format, $input, $this->timeZone);
 
-        if ( ! $dateTime instanceof DateTimeImmutable) {
-            throw new InvalidArgumentException("Invalid input for date/time fixation provided: {$input}");
+        if ( ! $dateTime instanceof \DateTimeImmutable) {
+            throw new \InvalidArgumentException("Invalid input for date/time fixation provided: {$input}");
         }
 
         $this->time = $dateTime;
     }
 
-    public function moveForward(DateInterval $interval): void
+    public function moveForward(\DateInterval $interval): void
     {
         $this->time = $this->now()->add($interval);
     }
 
-    public function now(): DateTimeImmutable
+    public function now(): \DateTimeImmutable
     {
         return $this->time;
     }
 
-    public function timeZone(): DateTimeZone
+    public function timeZone(): \DateTimeZone
     {
         return $this->timeZone;
     }

--- a/src/TestClockTest.php
+++ b/src/TestClockTest.php
@@ -4,11 +4,7 @@ declare(strict_types=1);
 
 namespace EventSauce\Clock;
 
-use DateInterval;
-use DateTimeZone;
-use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
-use function usleep;
 
 class TestClockTest extends TestCase
 {
@@ -30,7 +26,7 @@ class TestClockTest extends TestCase
     {
         $clock = new TestClock();
         $clock->fixate('2000-01-01 10:00:00');
-        $interval = new DateInterval('PT2H');
+        $interval = new \DateInterval('PT2H');
         $d1 = $clock->now();
         $clock->moveForward($interval);
         $d2 = $clock->now();
@@ -46,10 +42,10 @@ class TestClockTest extends TestCase
     public function it_exposes_a_timezone(): void
     {
         $clock = new TestClock();
-        $this->assertEquals(new DateTimeZone('UTC'), $clock->timeZone());
+        $this->assertEquals(new \DateTimeZone('UTC'), $clock->timeZone());
 
-        $clock = new TestClock(new DateTimeZone('Europe/Amsterdam'));
-        $this->assertEquals(new DateTimeZone('Europe/Amsterdam'), $clock->timeZone());
+        $clock = new TestClock(new \DateTimeZone('Europe/Amsterdam'));
+        $this->assertEquals(new \DateTimeZone('Europe/Amsterdam'), $clock->timeZone());
     }
 
     /**
@@ -59,7 +55,7 @@ class TestClockTest extends TestCase
     {
         $clock = new TestClock();
         $d1 = $clock->now();
-        usleep(1);
+        \usleep(1);
         $clock->tick();
         $d2 = $clock->now();
         $this->assertNotEquals($d1, $d2);
@@ -97,7 +93,7 @@ class TestClockTest extends TestCase
      */
     public function failing_to_fixate_the_clock(): void
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
         $clock = new TestClock();
         $clock->fixate('sihvwshv oihacih ohaciohc');
     }


### PR DESCRIPTION
Problem:

Using this package with PHP 8.4 leads to a deprecated error

“Implicitly marking parameter $timeZone as nullable is deprecated, the explicit nullable type must be used instead” 

Solution:
The PHP dependencies have been updated and the code adapted for PHP 8.4.